### PR TITLE
tooling: cleanup temp generation folder

### DIFF
--- a/scripts/generate-go-crd-clients/generate-clients.sh
+++ b/scripts/generate-go-crd-clients/generate-clients.sh
@@ -62,4 +62,4 @@ go run ${GOPATH_REPO_ROOT}/scripts/client-gen/main.go --clientset-name versioned
 # generated files out into a cleared pkg/client/ folder
 rm -rf client/
 mv ../github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/client .
-rm -rf ../cnrm.googlesource.com
+rm -rf ../github.com


### PR DESCRIPTION
I think this dir held the temp gen folder but now it's `github.com/...` so let's clean it up.
